### PR TITLE
get-data.sh: Change sh to bash.

### DIFF
--- a/examples/mnist/data/get-data.sh
+++ b/examples/mnist/data/get-data.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 TARGET_DIR="$1"
 


### PR DESCRIPTION
For a lot of users (especially on Ubuntu), sh will point to dash, not
bash, and this script uses bash builtins like `[[`.  So it should be
specifically run with bash.